### PR TITLE
Load org-element for using its functions

### DIFF
--- a/org-babel-eval-in-repl.el
+++ b/org-babel-eval-in-repl.el
@@ -45,6 +45,7 @@
 
 ;;; Code:
 (require 'ob)
+(require 'org-element)
 (require 'eval-in-repl)
 
 ;; @ Get data


### PR DESCRIPTION
This fixes byte-compile warnings.

```
org-babel-eval-in-repl.el:133:1:Warning: the following functions are not known to be defined:
    org-element-property, org-element-context, org-element-at-point
```