### PR TITLE
fix: don't mess up selected block when opening shell

### DIFF
--- a/org-babel-eval-in-repl.el
+++ b/org-babel-eval-in-repl.el
@@ -115,7 +115,8 @@ Returns nil if the cursor is outside a src block."
   "Evaluates an sh code block"
   (let ((eir-shell-buffer-name (ober-get-sh-session-name)))
     (when (not (get-buffer eir-shell-buffer-name))
-      (ober-repl-start-shell))
+      (save-mark-and-excursion
+        (ober-repl-start-shell)))
     (eir-eval-in-shell)))
 
 ;; Reference:


### PR DESCRIPTION
It seems that when `(ober-repl-start-shell)` is called, the selected text gets messed up and eventually `#+end_src` is sent for evaluation. This pull request just wraps the call inside `save-mark-and-excursion` to prevent this from happening.